### PR TITLE
G2-703 Remove relative path for parent POMs outside the project

### DIFF
--- a/gb-command-test/pom.xml
+++ b/gb-command-test/pom.xml
@@ -10,8 +10,8 @@
 		<relativePath>../gb-project/pom.xml</relativePath>
 	</parent>
 
-	<name>Gearbox Functional Test</name>
-	<description>Helper code for testing modules build on GearBox Functional.</description>
+	<name>Gearbox Command Test</name>
+	<description>Helper code for testing modules build on GearBox Command.</description>
 
 	<dependencies>
 		<dependency>

--- a/gb-command/pom.xml
+++ b/gb-command/pom.xml
@@ -10,7 +10,7 @@
 		<relativePath>../gb-project/pom.xml</relativePath>
 	</parent>
 
-	<name>Gearbox Functional</name>
+	<name>Gearbox Command</name>
 	<description>A functional abstraction of command line programs, allowing Java to invoke shell commands painlessly.</description>
 
 	<dependencies>

--- a/gb-project/pom.xml
+++ b/gb-project/pom.xml
@@ -10,7 +10,6 @@
 		<groupId>com.g2forge.alexandria</groupId>
 		<artifactId>ax-project</artifactId>
 		<version>0.0.12-SNAPSHOT</version>
-		<relativePath>../../alexandria/ax-project/pom.xml</relativePath>
 	</parent>
 
 	<properties>


### PR DESCRIPTION
Depends on https://github.com/g2forge/habitat/pull/18